### PR TITLE
Fixed startup issues for some users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 # Unreleased
 
+# 0.10.1 [Special Character Path Support]
+
+- Fixed startup issue for users that have a `'` or a ` ` in their Eclipse installation path.
+
 # 0.10.0 [Jahy-sama will not be discouraged!]
 
 **1 New Theme!**

--- a/plugin-feature/feature.xml
+++ b/plugin-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="io.unthrottled.doki.theme.eclipse"
       label="Doki-Theme-Eclipse"
-      version="0.10.0"
+      version="0.10.1"
       provider-name="Unthrottled">
 
    <description url="https://github.com/doki-theme/doki-theme-eclipse/blob/master/README.md#about">
@@ -66,7 +66,7 @@ SOFTWARE.
          id="doki-theme-eclipse"
          download-size="0"
          install-size="0"
-         version="0.10.0"
+         version="0.10.1"
          unpack="false"/>
 
 </feature>

--- a/plugin-source/META-INF/MANIFEST.MF
+++ b/plugin-source/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: doki-theme-eclipse;singleton:=true
-Bundle-Version: 0.10.0
+Bundle-Version: 0.10.1
 Bundle-Activator: io.unthrottled.doki.theme.Activator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-ClassPath: .

--- a/plugin-source/src/io/unthrottled/doki/theme/tools/URLTools.java
+++ b/plugin-source/src/io/unthrottled/doki/theme/tools/URLTools.java
@@ -1,0 +1,10 @@
+package io.unthrottled.doki.theme.tools;
+
+public class URLTools {
+
+  public static String sanitizeURLSString(String urlString) {
+    return urlString
+      .replaceAll(" ", "%20")
+      .replaceAll("'", "%27");
+  }
+}

--- a/plugin-update-site/site.xml
+++ b/plugin-update-site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/io.unthrottled.doki.theme.eclipse_0.10.0.jar" id="io.unthrottled.doki.theme.eclipse" version="0.10.0">
+   <feature url="features/io.unthrottled.doki.theme.eclipse_0.10.1.jar" id="io.unthrottled.doki.theme.eclipse" version="0.10.1">
       <category name="The Doki Theme"/>
    </feature>
    <category-def name="The Doki Theme" label="The Doki Theme">


### PR DESCRIPTION
## Changes

- Fixed startup issue for users that have a `'` or a ` ` in their Eclipse installation path.

## Motivation

Closes #5 
